### PR TITLE
Add more architectures to build for

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,4 +41,24 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: 'Binary Linux arm64 (Raspberry Pi)'
-        path: bin/mcsleepingserverstarter-linux-arm64       
+        path: bin/mcsleepingserverstarter-linux-arm64
+    - name: 'Upload Artifact MacOS (Apple Silicon)'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'Binary MacOS (Apple Silicon)'
+        path: bin/mcsleepingserverstarter-macos-arm64
+    - name: 'Upload Artifact MacOS (Intel)'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'Binary MacOS (Intel)'
+        path: bin/mcsleepingserverstarter-macos-x64
+    - name: 'Upload Artifact Alpine Linux'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'Binary Alpine Linux (Docker Container)'
+        path: bin/mcsleepingserverstarter-alpine-x64
+    - name: 'Upload Artifact Alpine Linux arm64'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'Binary Alpine Linux (arm64 Docker Container)'
+        path: bin/mcsleepingserverstarter-alpine-arm64

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "prebuild": "rimraf ./build/ ./bin/ && cpx-fixed \"views/**/*.*\" build/views",
         "build": "run-s build:typescript build:bin",
         "build:typescript": "tsc",
-        "build:bin": "pkg build/sleepingServerStarter.js --config package.json --compress GZip --target node18-win-x64,node18-linux-x64,node18-linux-arm64 --out-path ./bin/",
+        "build:bin": "pkg build/sleepingServerStarter.js --config package.json --compress GZip --target node18-win-x64,node18-linux-x64,node18-linux-arm64,node18-alpine-x64,node18-alpine-arm64,node18-macos-x64,node18-macos-arm64 --out-path ./bin/",
         "test": "echo \"Error: no test specified\" && exit 1",
         "lint": "eslint . --ext .ts --fix"
     },


### PR DESCRIPTION
Adding executables for:
- MacOS (Intel)
- MacOS (Apple Silicon)
- Alpine Linux (used for docker)
- Alpine Linux arm64 (used for docker on raspberry pi)