### PR TITLE
Fix `minecraftDirectory` not being used as base path when serving dynmap via web GUI

### DIFF
--- a/src/sleepingWeb.ts
+++ b/src/sleepingWeb.ts
@@ -53,14 +53,14 @@ export class SleepingWeb implements ISleepingServer {
       if (typeof this.settings.webServeDynmap === 'string') {
         dynmapPath = this.settings.webServeDynmap;
       } else {
-        dynmapPath = './plugins/dynmap/web/';
-        if (!existsSync(dynmapPath)) {
-          dynmapPath = path.join(__dirname, '../plugins/dynmap/web/');
-        }
+        const mcPath = this.settings.minecraftWorkingDirectory ?? process.cwd();
+        dynmapPath = path.join(mcPath, 'plugins/dynmap/web');
       }
       this.logger.info(`[WebServer] Serving dynmap: ${dynmapPath}`);
       if (existsSync(dynmapPath)) {
         this.app.use(`${this.webPath}/dynmap`, express.static(dynmapPath));
+      } else {
+        getLogger().error(`Dynmap directory at ${dynmapPath} does not exist!`);
       }
     }
 

--- a/src/sleepingWeb.ts
+++ b/src/sleepingWeb.ts
@@ -60,7 +60,7 @@ export class SleepingWeb implements ISleepingServer {
       if (existsSync(dynmapPath)) {
         this.app.use(`${this.webPath}/dynmap`, express.static(dynmapPath));
       } else {
-        getLogger().error(`Dynmap directory at ${dynmapPath} does not exist!`);
+        this.logger.error(`Dynmap directory at ${dynmapPath} does not exist!`);
       }
     }
 


### PR DESCRIPTION
When the `minecraftDirectory` setting is set, and `webServeDynmap` is set to true, the Web GUI still tries to serve the dynmap files from the mcsleepingserverstarter directory rather than from `minecraftDirectory`.

This PR fixes this issue so that it uses the `minecraftDirectory` value as the base path for loading the dynmap files. 