### PR TITLE
Fix node deprecation warnings when release build is run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - name: Save executables
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bin
           path: ./bin
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Retrieve saved executables
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: bin
           path: ./bin
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Retrieve saved executables
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: bin
           path: ./bin


### PR DESCRIPTION
This fixes the warnings seen in the annotations here: https://github.com/vincss/mcsleepingserverstarter/actions/runs/4588644673

Here is the build running successfully without any warnings: https://github.com/markmetcalfe/mcsleepingserverstarter/actions/runs/4590753697