### PR TITLE
Reduce size of docker image by only copying a single binary into the image when building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,9 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       - run: |
-          cp ./bin/mcsleepingserverstarter-linux-x64 ./docker/mcsleepingserverstarter-linux-x64
-          cp ./bin/mcsleepingserverstarter-linux-arm64 ./docker/mcsleepingserverstarter-linux-arm64
+          mkdir ./docker/mcsleepingserverstarter-linux
+          cp ./bin/mcsleepingserverstarter-linux-x64 ./docker/mcsleepingserverstarter-linux/amd64
+          cp ./bin/mcsleepingserverstarter-linux-arm64 ./docker/mcsleepingserverstarter-linux/arm64
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,8 @@
 FROM eclipse-temurin:17-jre-jammy
 
-# Copy both x64 and arm64 binaries
-COPY --chmod=755 ./mcsleepingserverstarter-linux-x64 /mcsleepingserverstarter-linux-x64
-COPY --chmod=755 ./mcsleepingserverstarter-linux-arm64 /mcsleepingserverstarter-linux-arm64
-
-# Only use the binary we need for the architecture
+# Will copy either "mcsleepingserverstarter-linux/amd64" or "mcsleepingserverstarter-linux/arm64"
+# depending on what architecture this image is for
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then rm /mcsleepingserverstarter-linux-arm64 && mv /mcsleepingserverstarter-linux-x64 /mcsleepingserverstarter; fi;
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then rm /mcsleepingserverstarter-linux-x64 && mv /mcsleepingserverstarter-linux-arm64 /mcsleepingserverstarter; fi;
+COPY --chmod=755 "./mcsleepingserverstarter-$TARGETPLATFORM" /mcsleepingserverstarter
 
 CMD /mcsleepingserverstarter


### PR DESCRIPTION
By only copying a single image into the image when building it, we reduce the final built image size down to 302MB from 418MB which it is currently. I've tested it and it works on both amd64 and arm64. Can test it yourself by using the `ghcr.io/markmetcalfe/mcsleepingserverstarter:v1.19` image.