### PR TITLE
[UX] Made the Sleep button disappear while server is online when "preventStop" is true

### DIFF
--- a/src/sleepingWeb.ts
+++ b/src/sleepingWeb.ts
@@ -19,6 +19,7 @@ export class SleepingWeb implements ISleepingServer {
   app: Express;
   server?: http.Server;
   webPath = "";
+  preventStop = false;
 
   constructor(
     settings: Settings,
@@ -28,6 +29,9 @@ export class SleepingWeb implements ISleepingServer {
     this.settings = settings;
     if (this.settings.webSubPath) {
       this.webPath = this.settings.webSubPath;
+    }
+    if (this.settings.preventStop) {
+      this.preventStop = this.settings.preventStop;
     }
     this.playerConnectionCallBack = playerConnectionCallBack;
     this.sleepingContainer = sleepingContainer;
@@ -126,7 +130,11 @@ export class SleepingWeb implements ISleepingServer {
 
     this.app.get(`${this.webPath}/status`, async (req, res) => {
       const status = await this.sleepingContainer.getStatus();
-      res.json({ status, dynmap: this.settings.webServeDynmap });
+      res.json({
+        status,
+        dynmap: this.settings.webServeDynmap,
+        settings: { preventStop: this.preventStop },
+      });
     });
 
     this.server = this.app.listen(this.settings.webPort, () => {
@@ -155,7 +163,7 @@ export class SleepingWeb implements ISleepingServer {
         this.logger.error(`Dynmap directory at ${dynmapPath} does not exist!`);
       }
     }
-  }
+  };
 
   close = async () => {
     if (this.server) {
@@ -163,5 +171,3 @@ export class SleepingWeb implements ISleepingServer {
     }
   };
 }
-
-

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -33,13 +33,17 @@
             .done(
                 (value) => {
                     console.log(`${new Date().toISOString()} - getStatus`, value);
-                    const { status, dynmap } = value;
+                    const { status, dynmap, settings } = value;
                     const { emoji, buttonText } = getTexts(status)
                     $('#server-status').text(`${emoji} ${status} ${emoji}`);
+                    
+                    const displayWakeBtn = (settings.preventStop && status === "Running") ? 'none' : 'unset';
+                    console.log(displayWakeBtn);
                     $('#wakeup-button').text(buttonText);
+                    $('#wakeup-button').css('display', displayWakeBtn);
 
-                    const display = dynmap ? 'unset' : 'none';
-                    $('#dynmap-button').css('display', display);
+                    const displayDynmap = dynmap ? 'unset' : 'none';
+                    $('#dynmap-button').css('display', displayDynmap);
                     dynmapLink = typeof dynmap === 'string' && dynmap.includes("http") ? dynmap : './dynmap';
                 })
             .fail(


### PR DESCRIPTION
This change now hides the "Sleep" button on the Web GUI while the server is in the "Running" state. This change only applies when the preventStop setting is set to true, where the button would not work anyway. Removing the button from the GUI when it is unneeded cleans up the screen and makes things look shiny!