### PR TITLE
Run mcsleeperstarter as a non-root user within the docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,17 @@ FROM eclipse-temurin:17-jre-jammy
 # Will copy either "mcsleepingserverstarter-linux/amd64" or "mcsleepingserverstarter-linux/arm64"
 # depending on what architecture this image is for
 ARG TARGETPLATFORM
-COPY --chmod=755 "./mcsleepingserverstarter-$TARGETPLATFORM" /mcsleepingserverstarter
+COPY --chmod=755 "./mcsleepingserverstarter-$TARGETPLATFORM" /mcsleepingserverstarter-bin
 
-CMD /mcsleepingserverstarter
+# Set up a non-root user to run the server as
+ARG USERNAME=minecraft
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN groupadd --gid $USER_GID $USERNAME && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+RUN mkdir /mcsleepingserverstarter
+RUN mv /mcsleepingserverstarter-bin /mcsleepingserverstarter
+RUN chown -R $USER_GUID:$USERNAME /mcsleepingserverstarter
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+USERNAME="minecraft"
+
+cp /sleepingSettings.yml /mcsleepingserverstarter
+
+# give control over to the non-root user
+chown -R $USERNAME /mcsleepingserverstarter
+chown -R $USERNAME /minecraft
+
+# run mcsleeperstarter as non-root
+cd /mcsleepingserverstarter
+exec runuser -u $USERNAME ./mcsleepingserverstarter-bin


### PR DESCRIPTION
This change makes it so the docker container creates a non-root user to run the mcsleeperstarter binary with, so that we no longer run the script, and therefore the minecraft server, as root.

Fixes #184