### PR TITLE
Update minecraft-motd-parser and associated methods to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@jsprismarine/bedrock-data": "^0.12.1",
         "@jsprismarine/brigadier": "^0.12.1",
         "@jsprismarine/prismarine": "^0.12.1",
-        "@sfirew/minecraft-motd-parser": "^1.1.1",
+        "@sfirew/minecraft-motd-parser": "^1.1.3",
         "express": "^4.21.1",
         "express-handlebars": "^7.0.4",
         "js-yaml": "^4.1.0",
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@sfirew/minecraft-motd-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@sfirew/minecraft-motd-parser/-/minecraft-motd-parser-1.1.1.tgz",
-      "integrity": "sha512-gXtpIgp+vCSlpyzd42Fg7nlx8vHmHwIrdWro7k1DcWu6Txq1abnFAKKlX0DFGLA9AazZCnC0HNrqCb+DGwiZTg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@sfirew/minecraft-motd-parser/-/minecraft-motd-parser-1.1.3.tgz",
+      "integrity": "sha512-wbuZsZ5dlSwOXLGa5thZbP7t1iiQTvyD8KJwWMrrYE4xqzmzHMwoE7mdhZYrEpDKS37sWiOjuxyx6Jf56YbBwg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@jsprismarine/bedrock-data": "^0.12.1",
     "@jsprismarine/brigadier": "^0.12.1",
     "@jsprismarine/prismarine": "^0.12.1",
-    "@sfirew/minecraft-motd-parser": "^1.1.1",
+    "@sfirew/minecraft-motd-parser": "^1.1.3",
     "express": "^4.21.1",
     "express-handlebars": "^7.0.4",
     "js-yaml": "^4.1.0",

--- a/src/sleepingHelper.ts
+++ b/src/sleepingHelper.ts
@@ -1,7 +1,7 @@
 import fs, { readFileSync } from "fs";
 import path from "path";
 import { createConnection } from "net";
-import { autoToHtml, cleanTags } from "@sfirew/minecraft-motd-parser";
+import { autoToHTML, cleanCodes } from "@sfirew/minecraft-motd-parser";
 import ChatMessage from "prismarine-chat";
 import { LATEST_MINECRAFT_VERSION } from "./version";
 import { getLogger } from "./sleepingLogger";
@@ -64,12 +64,12 @@ export const getMOTD = (
       : settings.serverMOTD;
 
   if (outputType === "plain") {
-    return cleanTags(motd);
+    return cleanCodes(motd);
   }
 
   if (outputType === "html") {
     // This automatically escapes any tags in the serverName to prevent XSS
-    return autoToHtml(motd);
+    return autoToHTML(motd);
   }
 
   return ChatMessage(settings.version || LATEST_MINECRAFT_VERSION)


### PR DESCRIPTION
This is just a small update to use minecraft-motd-parser to 1.1.3 instead of 1.1.1, there were two methods that were renamed

`autoToHtml` -> `autoToHTML` [View Update Commit](https://github.com/SnowFireWolf/minecraft-motd-parser/commit/bed92a7bd91f76e2566a6266faea0e216a5a6f0d)
`cleanTags`    -> `cleanCodes` [View Update Commit](https://github.com/SnowFireWolf/minecraft-motd-parser/commit/c288a7132b20fc798cf452367b7c32745f3c17ce)

 This fixes the problems encountered in #249